### PR TITLE
Remove wbsch repository

### DIFF
--- a/service/package_repositories.json
+++ b/service/package_repositories.json
@@ -68,7 +68,6 @@
     "menou": "https://raw.githubusercontent.com/Menoudb/TPFrenchCommunityTracker/main/repository.json",
     "kasper": "https://khaspri.github.io/repository.json",
     "chicdead26": "https://chicdead26.github.io/Super-Metroid-Map-Rando-Tracker/repository.json",
-    "wbsch": "https://www.wbsch.de/emotracker/repository.json",
     "exec": "https://raw.githubusercontent.com/Exec-6/ExTrack/main/repository.json",
     "Phantom": "https://emotracker.phantom-games.com/repository.json",
     "CommodoreCanadia64": "https://raw.githubusercontent.com/CommodoreCanadia64/PSIVPDTRACKER/main/repository.json",


### PR DESCRIPTION
Since the OoTMM map tracker was our only pack listed in this, and we're deprecating that, it doesn't make sense to keep it around. If we create a new EmoTracker pack at some point in the future, we'll just apply to re-add our repository URL.

Thanks for having us!