### PR TITLE
Delete package Cubesolver

### DIFF
--- a/service/package_repositories.json
+++ b/service/package_repositories.json
@@ -27,7 +27,6 @@
     "wolfman2000.github.io": "https://wolfman2000.github.io/trackers/repository.json",
     "dldarklink.github.io": "https://dldarklink.github.io/repository.json",
     "apokalysme.github.io": "https://apokalysme.github.io/emotracker/repository.json",
-    "cubesolver111": "https://raw.githubusercontent.com/cubesolver111/TMCMapTracker/main/repository.json",
     "muffinjets": "https://raw.githubusercontent.com/muffinjets/LADXMapTracker/master/repository.json",
     "aeralis": "https://raw.githubusercontent.com/Aeralis/Wings-of-Time-Tracker/master/repository.json",
     "stormridergaming": "https://stormridergaming.github.io/emotracker/repository.json",


### PR DESCRIPTION
I am requesting that the TMC pack from Cubesolver be removed, as it has not been compatible for over four years.