### PR TITLE
Migrate EmoTracker Official service URLs to GitHub-hosted content

### DIFF
--- a/service/package_repositories.json
+++ b/service/package_repositories.json
@@ -1,5 +1,5 @@
 {
-    "EmoTracker Official": "https://emotracker.net/service/packages/repository.json",
+    "EmoTracker Official": "https://raw.githubusercontent.com/EmoTracker-Community/EmoTracker-Service/main/service/packages/repository.json",
     "fouton.github.io": "https://fouton.github.io/repository.json",
     "dududedude.github.io": "https://dududedude.github.io/Dudude-s-Tinkering/repository.json",
     "jrjathome.github.io": "https://jrjathome.github.io/repository.json",

--- a/service/packages/repository.json
+++ b/service/packages/repository.json
@@ -9,7 +9,7 @@
       "flags": [ "official", "map", "pins", "chathud", "autotracker" ],
       "required_app_version": "2.3.8.8",
       "uid": "alttpr_emotracker_emosaru",
-      "link": "https://emotracker.net/service/packages/alttpr_emotracker_emosaru.zip",
+      "link": "https://raw.githubusercontent.com/EmoTracker-Community/EmoTracker-Service/main/service/packages/alttpr_emotracker_emosaru.zip",
       "variants": [
         {
           "name": "Item Tracker",


### PR DESCRIPTION
## Summary
- Updated `service/package_repositories.json` to point the EmoTracker Official repository entry to the GitHub-hosted `service/packages/repository.json`
- Updated `service/packages/repository.json` to point the ALTTP pack download link to the GitHub-hosted `alttpr_emotracker_emosaru.zip`

## Test plan
- [ ] Verify EmoTracker can fetch the repository listing from the new GitHub raw URL
- [ ] Verify the pack zip downloads correctly from the new GitHub raw URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)